### PR TITLE
Fixed 'active' highlight not showing on every other item in the list.

### DIFF
--- a/themes/nord-oneline.rasi
+++ b/themes/nord-oneline.rasi
@@ -81,6 +81,10 @@ element normal active {
     text-color: @accent-color;
 }
 
+element alternate active {
+    text-color: @accent-color;
+}
+
 element selected {
     text-color: @nord0;
 }

--- a/themes/nord-twoLines.rasi
+++ b/themes/nord-twoLines.rasi
@@ -76,6 +76,10 @@ element normal active {
     text-color: @accent-color;
 }
 
+element alternate active {
+    text-color: @accent-color;
+}
+
 element selected {
     text-color: @nord0;
 }

--- a/themes/nord.rasi
+++ b/themes/nord.rasi
@@ -80,6 +80,10 @@ element normal active {
     text-color: @accent-color;
 }
 
+element alternate active {
+    text-color: @accent-color;
+}
+
 element selected {
     text-color: @nord0;
 }

--- a/themes/rounded-common.rasi
+++ b/themes/rounded-common.rasi
@@ -79,6 +79,10 @@ element normal active {
     text-color: @bg3;
 }
 
+element alternate active {
+    text-color: @bg3;
+}
+
 element selected normal, element selected active {
     background-color:   @bg3;
 }

--- a/themes/simple-tokyonight.rasi
+++ b/themes/simple-tokyonight.rasi
@@ -87,6 +87,10 @@ element normal active {
   text-color: @accent;
 }
 
+element alternate active {
+  text-color: @accent;
+}
+
 element selected {
   text-color       : @bg1;
   background-color : @accent;

--- a/themes/spotlight-dark.rasi
+++ b/themes/spotlight-dark.rasi
@@ -84,6 +84,10 @@ element normal active {
     text-color: @bg2;
 }
 
+element alternate active {
+    text-color: @bg2;
+}
+
 element selected normal, element selected active {
     background-color:   @bg2;
     text-color:         @fg1;

--- a/themes/spotlight.rasi
+++ b/themes/spotlight.rasi
@@ -84,6 +84,10 @@ element normal active {
     text-color: @bg2;
 }
 
+element alternate active {
+    text-color: @bg2;
+}
+
 element selected normal, element selected active {
     background-color:   @bg2;
     text-color:         @fg1;

--- a/themes/squared-everforest.rasi
+++ b/themes/squared-everforest.rasi
@@ -74,6 +74,10 @@ element normal active {
     text-color: @accent-color;
 }
 
+element alternate active {
+    text-color: @accent-color;
+}
+
 element selected {
     text-color: @bg0;
 }

--- a/themes/squared-material-red.rasi
+++ b/themes/squared-material-red.rasi
@@ -74,6 +74,10 @@ element normal active {
     text-color: @accent-color;
 }
 
+element alternate active {
+    text-color: @accent-color;
+}
+
 element selected {
     text-color: @bg0;
 }

--- a/themes/squared-nord.rasi
+++ b/themes/squared-nord.rasi
@@ -74,6 +74,10 @@ element normal active {
     text-color: @accent-color;
 }
 
+element alternate active {
+    text-color: @accent-color;
+}
+
 element selected {
     text-color: @bg0;
 }

--- a/themes/windows11-grid-dark.rasi
+++ b/themes/windows11-grid-dark.rasi
@@ -90,6 +90,14 @@ element normal active {
   text-color: @accent;
 }
 
+element alternate active {
+  text-color: @accent;
+}
+
+element selected active {
+  text-color: @accent;
+}
+
 element selected {
   background-color: @bg3;
 }

--- a/themes/windows11-grid-light.rasi
+++ b/themes/windows11-grid-light.rasi
@@ -90,6 +90,14 @@ element normal active {
   text-color: @accent;
 }
 
+element alternate active {
+  text-color: @accent;
+}
+
+element selected active {
+  text-color: @accent;
+}
+
 element selected {
   background-color: @bg3;
 }

--- a/themes/windows11-list-dark.rasi
+++ b/themes/windows11-list-dark.rasi
@@ -89,6 +89,14 @@ element normal active {
   text-color: @accent;
 }
 
+element alternate active {
+  text-color: @accent;
+}
+
+element selected active {
+  text-color: @accent;
+}
+
 element selected {
   background-color: @bg3;
 }

--- a/themes/windows11-list-light.rasi
+++ b/themes/windows11-list-light.rasi
@@ -89,6 +89,14 @@ element normal active {
   text-color: @accent;
 }
 
+element alternate active {
+  text-color: @accent;
+}
+
+element selected active {
+  text-color: @accent;
+}
+
 element selected {
   background-color: @bg3;
 }


### PR DESCRIPTION
Hi, this is a fix for the 'active' highlight which doesn't always show.
There's an option to have the the active colour change for odd and even numbers, but only one was showing.
I couldn't fix it for the 'launchpad.rasi' file, the active highlight doesn't work at all on that one.

I've made it so all the odds and even list items get highlighted accurately.

In this example you'll see the orange text, that's how it should always look, but sometimes all the text is white.
![output](https://github.com/newmanls/rofi-themes-collection/assets/43177940/cef8d9c3-7712-44c7-91a9-ed94886f91f8)

If you want to test this bug yourself, run this code which will spam you out with rofi. Just press Esc loads of times to quit :).
```
cd rofi-themes-collection/themes
theme="rounded-orange-dark.rasi"
echo -e "f\hellp there\nme-youz\flumpity\naaaaaa\nmore\nof\nthese\nyay" | rofi -dmenu -selected-row 1 -a 1 -theme $theme
echo -e "f\hellp there\nme-youz\flumpity\naaaaaa\nmore\nof\nthese\nyay" | rofi -dmenu -selected-row 2 -a 2 -theme $theme
echo -e "f\hellp there\nme-youz\flumpity\naaaaaa\nmore\nof\nthese\nyay" | rofi -dmenu -selected-row 3 -a 3 -theme $theme
echo -e "f\hellp there\nme-youz\flumpity\naaaaaa\nmore\nof\nthese\nyay" | rofi -dmenu -selected-row 4 -a 4 -theme $theme
echo -e "f\hellp there\nme-youz\flumpity\naaaaaa\nmore\nof\nthese\nyay" | rofi -dmenu -selected-row 5 -a 5 -theme $theme
echo -e "f\hellp there\nme-youz\flumpity\naaaaaa\nmore\nof\nthese\nyay" | rofi -dmenu -selected-row 6 -a 6 -theme $theme
echo -e "f\hellp there\nme-youz\flumpity\naaaaaa\nmore\nof\nthese\nyay" | rofi -dmenu -selected-row 7 -a 7 -theme $theme
echo -e "f\hellp there\nme-youz\flumpity\naaaaaa\nmore\nof\nthese\nyay" | rofi -dmenu -selected-row 8 -a 8 -theme $theme
```