### PR TITLE
Rounded Common Bug Fix

### DIFF
--- a/themes/rounded-common.rasi
+++ b/themes/rounded-common.rasi
@@ -16,6 +16,7 @@ window {
     location:       north;
     y-offset:       calc(50% - 176px);
     width:          480;
+    height:         500;
     border-radius:  24px;
 
     background-color:   @bg0;


### PR DESCRIPTION
Recreation:
- hyprland + rofi
- have a few windows open in the background
- reduce the number of items in the list using the search bar causing the window to shrink in height
- move the mouse in and out of the rofi window and various windows in the background

-> causes rofi to flash and collapsing the list. Some time stabilized with only a single entry.

fixed by assigning a fixed height to the window.